### PR TITLE
CPAN Pull Request Challenge - Very small test improvements!

### DIFF
--- a/t/000_load.t
+++ b/t/000_load.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More no_plan => 1;
+use Test::More 'no_plan';
 
 BEGIN {
     use_ok('Catalyst::View::Excel::Template::Plus');

--- a/t/001_basic.t
+++ b/t/001_basic.t
@@ -29,9 +29,9 @@ BEGIN {
     
     my $excel = $response->content;
     
-    open FOO, '>', 'temp.xls' || die "Could not write temp file for testing : $!";
-    print FOO $excel;
-    close FOO;   
+    open my $fh_foo, '>', 'temp.xls' || die "Could not write temp file for testing : $!";
+    print $fh_foo $excel;
+    close $fh_foo;   
     
     cmp_excel_files("temp.xls", "t/xls/001_basic.xls", '... the generated excel file was correct');
 


### PR DESCRIPTION
Hi Stevan,

I got catalyst-view-excel-template-plus as my CPAN Pull Request Challenge distribution for January. Seems like it's a pretty small module so I only found a couple of small changes on my first look-over.

When running the tests I did get a very loud stack trace from Email::Template::Plus

```
Class::MOP::load_class is deprecated at /home/alex/perl5/perlbrew/perls/perl-5.20.1/lib/site_perl/5.20.1/x86_64-linux/Class/MOP.pm line 69.
    Class::MOP::load_class("Excel::Template::Plus::TT") called at /home/alex/perl5/perlbrew/perls/perl-5.20.1/lib/site_perl/5.20.1/Excel/Template/Plus.pm line 14
    eval {...} called at /home/alex/perl5/perlbrew/perls/perl-5.20.1/lib/site_perl/5.20.1/Excel/Template/Plus.pm line 14
...
    Catalyst::Test::_local_request("TestApp", "http://localhost/test_one") called at /home/alex/perl5/perlbrew/perls/perl-5.20.1/lib/site_perl/5.20.1/Catalyst/Test.pm line 32
    Catalyst::Test::__ANON__("http://localhost/test_one") called at t/001_basic.t line 20
```

As far as I can tell you've had your fingers in the pies of Email::Template::Plus and Class::MOP at one time or another so perhaps you could update Email::Template::Plus::TT to use whatever the correct alternative to Class::MOP::load_class() is?

If there are any other changes or feature requests you had in mind for catalyst-view-excel-template-plus let me know and I'll see if I can put in a slightly more impressive pull request before the end of January!

Thanks,

Alex
