### PR TITLE
Add support for Content-Disposition via stash options

### DIFF
--- a/lib/Catalyst/View/Excel/Template/Plus.pm
+++ b/lib/Catalyst/View/Excel/Template/Plus.pm
@@ -64,7 +64,17 @@ sub process {
 
     $excel->param( $self->get_template_params($c) );
 
+    # handle Content-Type
     $c->response->content_type('application/x-msexcel');
+
+    # handle Content-Disposition
+    my $excel_filename = $c->stash->{excel_filename} || 'excel.xls';
+    $excel_filename .= '.xls' unless ($excel_filename =~ /\.xls$/i);
+
+    my $excel_disposition = $c->stash->{excel_disposition} || 'inline';
+    $c->response->headers->header("Content-Disposition"
+        => qq{$excel_disposition; filename="$excel_filename"});
+
     $c->response->body($excel->output);
 }
 
@@ -116,6 +126,16 @@ through Excel::Template::Plus.
 =item I<etp_config>
 
 =item I<etp_params>
+
+=back
+
+=head1 STASH OPTIONS
+
+=over 4
+
+=item I<excel_disposition>
+
+=item I<excel_filename>
 
 =back
 

--- a/t/002_content_disposition.t
+++ b/t/002_content_disposition.t
@@ -1,0 +1,29 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use FindBin;
+use File::Spec;
+
+use lib (File::Spec->catdir($FindBin::Bin, 'lib'));
+
+use Test::More tests => 5;
+
+use Catalyst::Test 'TestApp';
+use Test::Excel::Template::Plus qw(cmp_excel_files);
+
+BEGIN {
+    use_ok('Catalyst::View::Excel::Template::Plus');
+}
+
+{
+    my $response = request('http://localhost/test_two');
+
+    ok(defined $response, '... got the response successfully');
+    ok($response->is_success, '... response is a success');
+    is($response->code, 200, '... response code is 200');
+    is_deeply(
+    [ $response->header('Content-Disposition') ],
+    [ 'attachment; filename="test.xls"' ],
+    '... the response content disposition is correct and sets the filename');
+}

--- a/t/lib/TestApp/Controller/Root.pm
+++ b/t/lib/TestApp/Controller/Root.pm
@@ -14,4 +14,16 @@ sub test_one : Global {
     $c->forward('TestApp::View::Excel');
 }
 
+sub test_two : Global {
+    my ($self, $c) = @_;
+
+    $c->stash->{template} = 'test_two.xml.tmpl';
+    $c->stash->{message} = 'Hello (Excel) World';
+
+    $c->stash->{excel_filename} = 'test';
+    $c->stash->{excel_disposition} = 'attachment';
+
+    $c->forward('TestApp::View::Excel');
+}
+
 1;

--- a/t/templates/test_two.xml.tmpl
+++ b/t/templates/test_two.xml.tmpl
@@ -1,0 +1,7 @@
+<workbook>
+    <worksheet>
+        <row>
+            <cell>[% message %]</cell>
+        </row>
+    </worksheet>
+</workbook>


### PR DESCRIPTION
Setting $c->stash->{excel_disposition} to a string will set that for the
Content-Disposition header. The default is "inline".

Setting $c->stash->{excel_filename} will set the filename appropriately
in the Content-Disposition header. The default is "excel.xls".

---

https://rt.cpan.org/Ticket/Display.html?id=68918
